### PR TITLE
fix(test): disable Redis in tests

### DIFF
--- a/src/main/java/com/aslmk/cloudfilestorage/config/SessionConfig.java
+++ b/src/main/java/com/aslmk/cloudfilestorage/config/SessionConfig.java
@@ -1,9 +1,11 @@
 package com.aslmk.cloudfilestorage.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.web.context.AbstractHttpSessionApplicationInitializer;
 
+@Profile("!test")
 @Configuration(proxyBeanMethods = false)
 @EnableRedisHttpSession
 public class SessionConfig extends AbstractHttpSessionApplicationInitializer {

--- a/src/test/java/com/aslmk/cloudfilestorage/NoRedisSessionTestConfig.java
+++ b/src/test/java/com/aslmk/cloudfilestorage/NoRedisSessionTestConfig.java
@@ -1,0 +1,28 @@
+package com.aslmk.cloudfilestorage;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.session.MapSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@TestConfiguration(proxyBeanMethods = false)
+@Profile("test")
+public class NoRedisSessionTestConfig {
+
+    @Bean
+    public static ConfigureRedisAction configureRedisAction() {
+        return ConfigureRedisAction.NO_OP;
+    }
+
+    @Bean
+    @Primary
+    public SessionRepository<? extends Session> sessionRepository() {
+        return new MapSessionRepository(new ConcurrentHashMap<>());
+    }
+}


### PR DESCRIPTION
Redis was starting up, preventing controller tests from running.

- Introduce NoRedisSessionTestConfig to mock Redis
- SessionConfig is now excluded in tests